### PR TITLE
Allow falsy non-string values to be passed to utility props

### DIFF
--- a/lib/utils/propsToUtilClasses.js
+++ b/lib/utils/propsToUtilClasses.js
@@ -10,7 +10,7 @@ export default (props) => {
     const utility = utilities.find(util => { return util.name.toLowerCase() === utilityKey })
 
     if (utility) {
-      const utilityValues = utilityValue.split(' ')
+      const utilityValues = typeof utilityValue === 'string' ? utilityValue.split(' ') : [];
 
       return utilityValues.map(utilityValue => {
 

--- a/test/Base.spec.js
+++ b/test/Base.spec.js
@@ -33,4 +33,10 @@ describe('Base', () => {
     expect(wrapper.hasClass('u-text-center')).toBe(true);
   })
 
+  test('It accepts falsy non-string values for utility props', () => {
+    const wrapper = shallow(<Base uCf={false} />)
+
+    expect(wrapper.hasClass('u-cf')).toBe(false);
+  })
+
 })


### PR DESCRIPTION
This helps when conditionally setting a utility prop.