### PR TITLE
Pass through unrelated props in Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ const App = () => (
 
 ### Base
 
-The Base is responsible for translating `u` prefixed properties to iotaCSS utility classes, for example `uText="center"` will translate to `class="u-text-center"`. It's extended by all the React Components and you should use it in all your components if you want them to support React iotaCSS utility properties.
+The Base is responsible for translating `u` prefixed properties to iotaCSS utility classes, for example `uText="center"` will translate to `class="u-text-center"`. It's extended by all the React Components and you should use it in all your components if you want them to support React iotaCSS utility properties. Properties that are not specific to `Base` will be passed down to to the rendered `tagName`.
 
 #### Properties
 
-| Name     | Type    | Default | Description                 |
-| ---      | ---     | ---     | ---                         |
-| tagName  | String  | div     | TagName to be used          |
+| Name      | Type    | Default | Description                 |
+| ---       | ---     | ---     | ---                         |
+| tagName   | String  | div     | TagName to be used          |
 
 #### Example
 

--- a/lib/Base.js
+++ b/lib/Base.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import propsToUtilClasses from './utils/propsToUtilClasses'
+import restProps from './utils/restProps'
 
 
 class Base extends Component {
@@ -21,7 +22,6 @@ class Base extends Component {
     /** Applies extra classes to component */
     className: PropTypes.string,
 
-    style: PropTypes.object,
     /** HTML element or React component to render */
     children: PropTypes.node,
 
@@ -87,17 +87,17 @@ class Base extends Component {
     const {
       tagName:Component,
       children,
-      style,
       className,
-      ...props
     } = this.props
 
     const classes = classnames(className,
       propsToUtilClasses(this.props)
     )
+    
+    const rest = restProps(Base.propTypes, this.props);
 
     return (
-      <Component className={classes} style={style}>
+      <Component className={classes} {...rest}>
         {children}
       </Component>
     )

--- a/lib/utils/restProps.js
+++ b/lib/utils/restProps.js
@@ -1,0 +1,7 @@
+export default (propTypes = {}, props = {}) => Object.keys(props)
+  .filter(prop => !propTypes.hasOwnProperty(prop))
+  .reduce((previousValue, currentValue) => (
+      Object.assign(previousValue, {
+        [currentValue]: props[currentValue]
+      })
+  ), {});

--- a/test/Base.spec.js
+++ b/test/Base.spec.js
@@ -39,4 +39,9 @@ describe('Base', () => {
     expect(wrapper.hasClass('u-cf')).toBe(false);
   })
 
+  test('It passes down any props that are not specific to Base', () => {
+    const wrapper = shallow(<Base title="Hello there" />)
+    expect(wrapper.getNode().props.title).toBe('Hello there');
+  })
+
 })


### PR DESCRIPTION
This is necessary to be able to pass down regular HTML attributes or properties specific to a component that is wrapped in Base