### PR TITLE
Allow tagName property in List

### DIFF
--- a/lib/List.js
+++ b/lib/List.js
@@ -23,6 +23,7 @@ const List = ({
   type,
   gutter,
   align,
+  tagName,
   children,
   ...props
 }) => {
@@ -33,7 +34,7 @@ const List = ({
   })
 
   return (
-    <Base tagName="ul" className={classes} {...props}>
+    <Base tagName={tagName} className={classes} {...props}>
       {children}
     </Base>
   )
@@ -41,7 +42,8 @@ const List = ({
 
 
 List.defaultProps = {
-  type: 'inline'
+  type: 'inline',
+  tagName: 'ul'
 }
 
 
@@ -49,6 +51,7 @@ List.propTypes = {
   type: PropTypes.string,
   gutter: PropTypes.string,
   align: PropTypes.oneOf(VALIGN_OPTIONS),
+  tagName: PropTypes.oneOf(['ul', 'ol']),
   children: PropTypes.node
 }
 

--- a/test/List.spec.js
+++ b/test/List.spec.js
@@ -45,4 +45,10 @@ describe('List', () => {
     expect(wrapper.hasClass('o-list--top')).toBe(true);
   })
 
+  test('It accepts tagName property', () => {
+    const wrapper = shallow(<List tagName="ol" />)
+
+    expect(wrapper.is('<ol />'));
+  })
+
 })


### PR DESCRIPTION
Only `ul` and `ol` are allowed via prop types.
It might make sense semantically to make a list an ordered list in certain cases.