### PR TITLE
Make React a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   "homepage": "https://github.com/iotacss/react-iotacss#readme",
   "dependencies": {
     "classnames": "^2.2.5",
-    "prop-types": "^15.5.10",
-    "react": "^15.5.4"
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -43,18 +43,24 @@
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.24.1",
     "css-loader": "^0.28.3",
-    "enzyme": "^2.8.2",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
     "file-loader": "^0.11.2",
     "iotacss": "^1.1.1",
     "jest": "^20.0.4",
     "node-sass": "^4.5.3",
     "path": "^0.12.7",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.6.0",
-    "react-test-renderer": "^15.5.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "sass-loader": "^6.0.5",
     "style-loader": "^0.18.1",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/test/support/polyfills.js",
+      "<rootDir>/test/support/enzyme.js"
+    ]
   }
 }

--- a/test/Base.spec.js
+++ b/test/Base.spec.js
@@ -24,7 +24,7 @@ describe('Base', () => {
   test('It accepts tagName property', () => {
     const wrapper = shallow(<Base tagName="h1" />)
 
-    expect(wrapper.is('<h1 />'));
+    expect(wrapper.is('h1'));
   })
 
   test('It parses utility properties', () => {
@@ -47,7 +47,7 @@ describe('Base', () => {
 
   test('It passes down any props that are not specific to Base', () => {
     const wrapper = shallow(<Base title="Hello there" />)
-    expect(wrapper.getNode().props.title).toBe('Hello there');
+    expect(wrapper.getElement().props.title).toBe('Hello there');
   })
 
 })

--- a/test/List.spec.js
+++ b/test/List.spec.js
@@ -54,7 +54,7 @@ describe('List', () => {
   test('It accepts tagName property', () => {
     const wrapper = shallow(<List tagName="ol" />)
 
-    expect(wrapper.is('<ol />'));
+    expect(wrapper.is('ol'));
   })
 
 })

--- a/test/support/enzyme.js
+++ b/test/support/enzyme.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/test/support/polyfills.js
+++ b/test/support/polyfills.js
@@ -1,0 +1,3 @@
+global.requestAnimationFrame = function (cb) {
+  return setTimeout(cb, 0);
+};


### PR DESCRIPTION
to support React-like libraries such as Inferno and Preact without
needing to install React + to only have a single React package installed
per project.

[See here](https://stackoverflow.com/a/30454133)