### PR TITLE
Added polyfills for IE11

### DIFF
--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -1,0 +1,52 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find?v=example#Polyfill
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, "find", {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined')
+      }
+
+      var o = Object(this)
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== "function") {
+        throw new TypeError("predicate must be a function")
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1]
+
+      // 5. Let k be 0.
+      var k = 0
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k]
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue
+        }
+        // e. Increase k by 1.
+        k++
+      }
+
+      // 7. Return undefined.
+      return undefined
+    },
+  })
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position) {
+    return this.substr(position || 0, searchString.length) === searchString
+  }
+}

--- a/src/utils/propsToUtilClasses.js
+++ b/src/utils/propsToUtilClasses.js
@@ -1,4 +1,5 @@
 import utilities from './utilsList'
+import './polyfills.js'
 
 export default (props) => {
   let className = ''


### PR DESCRIPTION
Hi @harby - I recently deployed a change to projects.raspberrypi.org that involved react-iotacss (it's being used in our Pattern Library), but shortly after deploying we started hearing that the site was broken in IE11.

True enough it was! I did some investigation, and tracked it down to the following lines in react-iotacss:

* https://github.com/iotacss/react-iotacss/blob/master/src/utils/propsToUtilClasses.js#L10
* https://github.com/iotacss/react-iotacss/blob/master/src/utils/propsToUtilClasses.js#L25

 IE11 does not support the following JavaScript methods:

* Array.prototype.find
* String.prototype.startsWith

I successfully polyfilled our application so that we could bring back IE11 support, but thought I'd also shoot you a PR so that they get fixed for everyone. It makes sense that react-iotacss supports the same browsers as React itself!

Hope this has been useful. Let me know if this needs work :)

